### PR TITLE
Fix mobile viewport scaling on documentation page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>The Intelligence Hub Documentation</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css">
   <style>
@@ -16,11 +16,15 @@
       --sidebar-width: 280px;
       --header-height: 60px;
     }
+    html, body {
+      margin: 0;
+      padding: 0;
+      max-width: 100%;
+      overflow-x: hidden;
+    }
     body {
       font-family: Arial, sans-serif;
       line-height: 1.6;
-      margin: 0;
-      padding: 0;
       background-color: var(--bg-color);
       color: var(--text-color);
     }


### PR DESCRIPTION
## Summary
- prevent mobile zoom with stricter viewport settings
- constrain document width and hide horizontal overflow for better centering on small screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689164d6c850832e88b1e1935c0d30f0