### PR TITLE
fix: close mobile menu after link click

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2078,6 +2078,15 @@ await hubConnection.InvokeAsync("Send", request);</code></pre>
       const sidebar = document.getElementById('sidebar');
       sidebar.classList.toggle('open');
     }
+    // Close the sidebar when a menu link is clicked on small screens
+    document.querySelectorAll('#sidebar a').forEach(link => {
+      link.addEventListener('click', () => {
+        if (window.innerWidth <= 768) {
+          const sidebar = document.getElementById('sidebar');
+          sidebar.classList.remove('open');
+        }
+      });
+    });
     document.querySelectorAll('.copy-btn').forEach(btn => {
       btn.addEventListener('click', () => {
         const code = btn.nextElementSibling.querySelector('code').textContent;


### PR DESCRIPTION
## Summary
- ensure mobile navigation closes when a menu link is tapped

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891646d4564832eaa2b800733ac825d