### PR TITLE
Fix anchor overlap and update header text

### DIFF
--- a/docs/ReadMe.md
+++ b/docs/ReadMe.md
@@ -1,4 +1,4 @@
-# The Intelligence Hub
+# The Intelligence Hub Documentation
 ### A robust wrapper for popular AI services, designed to streamline AI-powered app development while ensuring reliability and effortless cross-service configuration.
 ---
 ## Table of Contents

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,6 +74,7 @@
     }
     section {
       margin-bottom: 3rem;
+      scroll-margin-top: calc(var(--header-height) + 1rem);
     }
     h1, h2, h3, h4 {
       color: var(--text-color);
@@ -170,7 +171,7 @@
 <body>
   <header>
     <button class="menu-toggle" onclick="toggleMenu()">☰</button>
-    <h1>The Intelligence Hub</h1>
+    <h1>The Intelligence Hub Documentation</h1>
   </header>
   <nav id="sidebar">
     <h2>Table of Contents</h2>


### PR DESCRIPTION
## Summary
- prevent section headings from hiding behind the fixed banner
- rename banner and README heading to "The Intelligence Hub Documentation"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689169a9d998832ebfdea55d8c3a0501